### PR TITLE
Fix signature pre-image mismatch caused by browser-modified header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/sdk": "^1.4.9",
+        "@bsv/sdk": "^1.4.10",
         "express": "^4.21.2"
       },
       "devDependencies": {
@@ -536,9 +536,9 @@
       "dev": true
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.9.tgz",
-      "integrity": "sha512-HoEhJF1gErXhyQ+CbdMS1uFQ138QfbM08ys1745GTJqeMbj4vWRNMWBIDr9RcTmXZofHvf6WUhLuCcq2sciuKw==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.10.tgz",
+      "integrity": "sha512-LvaKfHiIFHWGdgk3ujQDjKKWQo2lGkcOS0A0Ly4AE1+uUp611iVQ1gKUU0yF7uUVIwZDwiJoVComb2cg2PM+lA==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/auth-express-middleware",
-      "version": "1.0.13",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/sdk": "^1.4.0",
+        "@bsv/sdk": "^1.4.9",
         "express": "^4.21.2"
       },
       "devDependencies": {
@@ -536,9 +536,9 @@
       "dev": true
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.0.tgz",
-      "integrity": "sha512-UnLbQwX1MSFU4JjK4EG7BJvnM0Bk0sF0eW08whUT3n3fjUxPODnL45hFmU+rMi62UDyAtzPlKfv8LL9nPkLXWQ==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.9.tgz",
+      "integrity": "sha512-HoEhJF1gErXhyQ+CbdMS1uFQ138QfbM08ys1745GTJqeMbj4vWRNMWBIDr9RcTmXZofHvf6WUhLuCcq2sciuKw==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "BSV Blockchain mutual-authentication express middleware",
   "type": "module",
   "main": "dist/cjs/mod.js",
@@ -56,7 +56,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@bsv/sdk": "^1.4.0",
+    "@bsv/sdk": "^1.4.9",
     "express": "^4.21.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@bsv/sdk": "^1.4.9",
+    "@bsv/sdk": "^1.4.10",
     "express": "^4.21.2"
   }
 }

--- a/src/__tests/integration.test.ts
+++ b/src/__tests/integration.test.ts
@@ -425,4 +425,24 @@ describe('AuthFetch and AuthExpress Integration Tests', () => {
     console.log('Data from second AuthFetch instance (after server restart):', data2)
     expect(data2).toBeDefined()
   }, 150000)
+
+  test('Test 15: POST request with JSON header containing charset injection', async () => {
+    const walletWithRequests = new CompletedProtoWallet(privKey)
+    const authFetch = new AuthFetch(walletWithRequests)
+    const result = await authFetch.fetch(
+      'http://localhost:3000/other-endpoint',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json; charset=utf-8'
+        },
+        body: JSON.stringify({ message: 'Testing charset injection normalization!' })
+      }
+    )
+    expect(result.status).toBe(200)
+    const jsonResponse = await result.json()
+    console.log(jsonResponse)
+    expect(jsonResponse).toBeDefined()
+  }, 15000)
+
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -689,7 +689,7 @@ function buildAuthMessageFromRequest(
   const includedHeaders: [string, string][] = []
   for (let [k, v] of Object.entries(req.headers)) {
     k = k.toLowerCase()
-    if ((k.startsWith('x-bsv-') || k === 'content-type' || k === 'authorization') && !k.startsWith('x-bsv-auth')) {
+    if ((k.startsWith('x-bsv-') || k === 'authorization') && !k.startsWith('x-bsv-auth')) {
       includedHeaders.push([k, v as string])
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -689,7 +689,12 @@ function buildAuthMessageFromRequest(
   const includedHeaders: [string, string][] = []
   for (let [k, v] of Object.entries(req.headers)) {
     k = k.toLowerCase()
-    if ((k.startsWith('x-bsv-') || k === 'authorization') && !k.startsWith('x-bsv-auth')) {
+    // Normalize the Content-Type header by removing any parameters.
+    if (k === 'content-type') {
+      v = (v as string).split(';')[0].trim()
+    }
+
+    if ((k.startsWith('x-bsv-') || k === 'content-type' || k === 'authorization') && !k.startsWith('x-bsv-auth')) {
       includedHeaders.push([k, v as string])
     }
   }


### PR DESCRIPTION
Chrome sometimes automatically appends ; charset=utf-8 to the Content-Type header (application/json becomes application/json; charset=utf-8). This causes signature verification to fail, since the client originally signed application/json.

To resolve this issue, I propose normalizing the content-type header to prevent causing a breaking change, while providing a fix to this issue I have observed while integration testing.