### PR TITLE
Added better error/session handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,9 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testPathIgnorePatterns: ['dist/'],
-  modulePathIgnorePatterns: ['<rootDir>/dist/'] // Add this to ignore dist/ for module mapping
+  modulePathIgnorePatterns: ['<rootDir>/dist/'], // Add this to ignore dist/ for module mapping
+  // Integration tests use fixed ports and multi-round-trip auth protocol
+  // exchanges that require sequential execution to avoid worker event-loop
+  // scheduling issues and port conflicts.
+  maxWorkers: 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/auth-express-middleware",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/sdk": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@bsv/sdk": "^2.0.0",
+        "@bsv/sdk": "^2.0.4",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -525,9 +525,9 @@
       "license": "MIT"
     },
     "node_modules/@bsv/sdk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.0.tgz",
-      "integrity": "sha512-W6CoAFRnYAetr8d90odwjdvIAgtV6CVUWeH5OhBwUrdDsHA8GAlv492VMwcQ+Eh46GfuXrnPvvW+fE25fMswNg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.4.tgz",
+      "integrity": "sha512-5SUK76szpScNmpjx8iupZFWjksz4e4mjzxBbtEaz5LBDjvXeseBFRRmGpeiBnlGtnKd7GVBblW8ZfwjzFM92dg==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6751,9 +6751,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/auth-express-middleware",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/sdk": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "BSV Blockchain mutual-authentication express middleware",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/auth-express-middleware",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "BSV Blockchain mutual-authentication express middleware",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@bsv/sdk": "^2.0.0",
+    "@bsv/sdk": "^2.0.4",
     "express": "^5.1.0"
   }
 }


### PR DESCRIPTION
### Fixed
- Return 401 for auth failures (stale session, bad nonce/signature); reserve 500 for internal errors.
- Catch errors in `buildAndSendResponse` — return 500 instead of hanging.
- Track and clear certificate wait timers to prevent dangling handles.

### Tests
- Await `server.ready` in `beforeAll` to eliminate cert seeding race.
- Add stale-session recovery tests (Tests 14–15).
- Use `maxWorkers: 1` for fixed-port integration tests.